### PR TITLE
Make `tanka.Path` optional

### DIFF
--- a/docs/pages/configuration/_partials/v2beta1/deployments/tanka/envpath.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/tanka/envpath.mdx
@@ -4,7 +4,7 @@
 
 #### `environmentPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-tanka-environmentPath}
 
-EnvironmentPath is the (relative) path to a specific tanka environment.
+EnvironmentPath is the (relative) path to a specific tanka environment. In case Path is ommited it will be used to discover Tanka project's root. Look at Path parameter for mor details.
 
 </summary>
 

--- a/docs/pages/configuration/_partials/v2beta1/deployments/tanka/path.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/tanka/path.mdx
@@ -4,7 +4,7 @@
 
 #### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-tanka-path}
 
-Path is the (relative) path of the tanka environment, usually identified by jsonnetfile.json.
+Path is the (relative) path of the tanka environment, usually identified by jsonnetfile.json. It can be ommited if environmentPath is set and is also relative to the working directory (Tanka's project directory tree). If omitted, Devspace will traverse in reverse environmentPath looking for jsonnetfile.json, when found, that will be set as Path. Otherwise will throw an error.
 
 </summary>
 

--- a/e2e/tests/deploy/testdata/tanka/devspace.yaml
+++ b/e2e/tests/deploy/testdata/tanka/devspace.yaml
@@ -9,7 +9,6 @@ deployments:
     tanka:
       runJsonnetBundlerInstall: true
       runJsonnetBundlerUpdate: true
-      path: .
       environmentPath: environments/default
       externalStringVariables:
         IMAGE_NGINX: ${IMAGE_NGINX}

--- a/e2e/tests/replacepods/testdata/dev-image/devspace.yaml
+++ b/e2e/tests/replacepods/testdata/dev-image/devspace.yaml
@@ -8,7 +8,6 @@ deployments:
   # Define a tanka deployment
   nginx:
     tanka:
-      path: .
       environmentPath: environments/default
       externalStringVariables:
         IMAGE_NGINX: ${IMAGE_NGINX}
@@ -16,4 +15,4 @@ deployments:
 dev:
   nginx:
     imageSelector: ${IMAGE_NGINX}
-    devImage: nginx:perl  
+    devImage: nginx:perl

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -831,6 +831,7 @@ type RollingUpdateConfig struct {
 // TankaConfig defines the specific tanka options used during deployment.
 type TankaConfig struct {
 	// Path is the (relative) path of the tanka environment, usually identified by jsonnetfile.json.
+	// It can be ommited if environmentPath is set and is also relative to the working directory (Tanka's project directory tree). If omitted, Devspace will traverse in reverse environmentPath looking for jsonnetfile.json, when found, that will be set as Path. Otherwise will throw an error.
 	Path string `yaml:"path,omitempty" json:"path,omitempty"`
 	// RunJsonnetBundlerInstall indicates if the `jb install` command shall be run, default to true
 	RunJsonnetBundlerInstall *bool `yaml:"runJsonnetBundlerInstall,omitempty" json:"runJsonnetBundlerInstall,omitempty"`
@@ -838,6 +839,7 @@ type TankaConfig struct {
 	RunJsonnetBundlerUpdate *bool `yaml:"runJsonnetBundlerUpdate,omitempty" json:"runJsonnetBundlerUpdate,omitempty"`
 
 	// EnvironmentPath is the (relative) path to a specific tanka environment.
+	// In case Path is ommited it will be used to discover Tanka project's root. Look at Path parameter for more details.
 	EnvironmentPath string `yaml:"environmentPath,omitempty" json:"environmentPath,omitempty"`
 	// When using environment auto-discovery, this maps to the `--name` parameter
 	EnvironmentName string `yaml:"environmentName,omitempty" json:"environmentName,omitempty"`

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -831,7 +831,7 @@ type RollingUpdateConfig struct {
 // TankaConfig defines the specific tanka options used during deployment.
 type TankaConfig struct {
 	// Path is the (relative) path of the tanka environment, usually identified by jsonnetfile.json.
-	// It can be ommited if environmentPath is set and is also relative to the working directory (Tanka's project directory tree). If omitted, Devspace will traverse in reverse environmentPath looking for jsonnetfile.json, when found, that will be set as Path. Otherwise will throw an error.
+	// It can be omitted if environmentPath is set and is also relative to the working directory (Tanka's project directory tree). If omitted, Devspace will traverse in reverse environmentPath looking for jsonnetfile.json, when found, that will be set as Path. Otherwise will throw an error.
 	Path string `yaml:"path,omitempty" json:"path,omitempty"`
 	// RunJsonnetBundlerInstall indicates if the `jb install` command shall be run, default to true
 	RunJsonnetBundlerInstall *bool `yaml:"runJsonnetBundlerInstall,omitempty" json:"runJsonnetBundlerInstall,omitempty"`
@@ -839,7 +839,7 @@ type TankaConfig struct {
 	RunJsonnetBundlerUpdate *bool `yaml:"runJsonnetBundlerUpdate,omitempty" json:"runJsonnetBundlerUpdate,omitempty"`
 
 	// EnvironmentPath is the (relative) path to a specific tanka environment.
-	// In case Path is ommited it will be used to discover Tanka project's root. Look at Path parameter for more details.
+	// In case Path is omitted it will be used to discover Tanka project's root. Look at Path parameter for more details.
 	EnvironmentPath string `yaml:"environmentPath,omitempty" json:"environmentPath,omitempty"`
 	// When using environment auto-discovery, this maps to the `--name` parameter
 	EnvironmentName string `yaml:"environmentName,omitempty" json:"environmentName,omitempty"`

--- a/pkg/devspace/deploy/deployer/tanka/builder.go
+++ b/pkg/devspace/deploy/deployer/tanka/builder.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -114,7 +113,7 @@ func NewTankaEnvironment(config *latest.TankaConfig) TankaEnvironment {
 
 // Given a tkPath, look for the root of Tanka project based on jsonnetfile.json file existence
 func searchTankaRootDir(tkPath string) (string, error) {
-	files, err := ioutil.ReadDir(tkPath)
+	files, err := os.ReadDir(tkPath)
 	if err != nil {
 		log.Fatalf("Error reading %v: %v", tkPath, err)
 	}
@@ -130,7 +129,7 @@ func searchTankaRootDir(tkPath string) (string, error) {
 		log.Fatalf("Error getting absolute path for %v: %v", tkPath, err)
 	}
 	if filepath.Join(tkPathAbs, "..") == tkPathAbs { // Reached the root of the filesystem
-		return "", fmt.Errorf("Could not find root of Tanka project looking for a 'jsonnetfile.json' file")
+		return "", fmt.Errorf("could not find root of Tanka project looking for a 'jsonnetfile.json' file")
 	}
 	return searchTankaRootDir(filepath.Join(tkPath, ".."))
 }

--- a/pkg/devspace/deploy/deployer/tanka/validate.go
+++ b/pkg/devspace/deploy/deployer/tanka/validate.go
@@ -13,8 +13,8 @@ func validateConfig(cfg *latest.DeploymentConfig) error {
 
 	if cfg.Tanka == nil {
 		errors = append(errors, "tanka is nil")
-	} else if cfg.Tanka.Path == "" {
-		errors = append(errors, "tanka.path is not defined")
+	} else if cfg.Tanka.Path == "" && cfg.Tanka.EnvironmentPath == "" {
+		errors = append(errors, "neither tanka.path nor tanka.environmentPath is configured")
 	} else if cfg.Tanka.EnvironmentName == "" && cfg.Tanka.EnvironmentPath == "" {
 		errors = append(errors, "neither tanka.environmentName nor tanka.environmentPath is configured")
 	}

--- a/pkg/devspace/deploy/deployer/tanka/validate_test.go
+++ b/pkg/devspace/deploy/deployer/tanka/validate_test.go
@@ -23,7 +23,7 @@ func Test_validateConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "path not defined",
+			name: "path and environmentPath not defined",
 			args: args{
 				cfg: &latest.DeploymentConfig{Tanka: &latest.TankaConfig{
 					EnvironmentName: "test",
@@ -41,7 +41,7 @@ func Test_validateConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "welldefined with environmentName",
+			name: "welldefined with path and environmentName",
 			args: args{
 				cfg: &latest.DeploymentConfig{Tanka: &latest.TankaConfig{
 					Path:            "./kubernetes/",
@@ -51,20 +51,30 @@ func Test_validateConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "welldefined with environmentPath",
+			name: "welldefined with path and environmentPath",
 			args: args{
 				cfg: &latest.DeploymentConfig{Tanka: &latest.TankaConfig{
 					Path:            "./kubernetes/",
-					EnvironmentPath: "./kubernetes/environments/devspace",
+					EnvironmentPath: "environments/devspace",
 				}},
 			},
 			wantErr: false,
 		},
 		{
-			name: "welldefined with environmentPath and name",
+			name: "welldefined with path, environmentPath and name",
 			args: args{
 				cfg: &latest.DeploymentConfig{Tanka: &latest.TankaConfig{
 					Path:            "./kubernetes/",
+					EnvironmentPath: "environments/production",
+					EnvironmentName: "devspace/my-demo-app",
+				}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "welldefined with environmentPath and name and no path",
+			args: args{
+				cfg: &latest.DeploymentConfig{Tanka: &latest.TankaConfig{
 					EnvironmentPath: "./kubernetes/environments/production",
 					EnvironmentName: "devspace/my-demo-app",
 				}},


### PR DESCRIPTION
This makes deployment.tanka.path optional. When not defined, devspace will try to discover the root of the Tanka project by looking for `jsonnetfile.json` traversing in reverse the current directory up to the root of the filesystem.

Since we can discover Tanka root directory, we need to make deployment.tanka.path optional, but it can also coexist with deployment.tanka.environmentPath. If no `path`, then `environmentPath` must be relative to current directory (project's directory).